### PR TITLE
add boot_from_file_path_cgi

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -40,8 +40,12 @@ MRuby::Build.new do |conf|
 
   # when using openssl from brew
   if RUBY_PLATFORM =~ /darwin/i
+    conf.cc do |cc|
+      cc.flags << '-I /usr/local/include -I/usr/local/opt/openssl/include'
+    end
+
     conf.linker do |linker|
-      linker.option_library_path << ' -L/usr/local/lib/ '
+      linker.option_library_path << ' -L/usr/local/lib/ -L/usr/local/opt/openssl/lib'
     end
   end
 end

--- a/build_config.rb
+++ b/build_config.rb
@@ -16,7 +16,7 @@ MRuby::Build.new do |conf|
   conf.gem :github => 'mattn/mruby-json'
   conf.gem :github => 'kjunichi/mruby-getprocpath'
   conf.gem :github => 'ksss/mruby-signal', :branch => 'master'
-  
+  conf.gem :github => "kou/mruby-pp"
   if RUBY_PLATFORM =~ /linux/i
     conf.gem :github => 'kjunichi/mruby-inotify'
     conf.gem :github => 'ksss/mruby-file-stat'

--- a/examples/test.conf.rb
+++ b/examples/test.conf.rb
@@ -115,13 +115,13 @@ s = HTTP2::Server.new({
 if s.request.uri == "/test"
   p s.request
   p "test"
-  MyCall.my_exec("this is trusterd!")
+
   s.set_content_cb {
     s.rputs s.unparsed_uri+"\n"
     if s.body
       s.rputs s.body+"\n"
     end
-    s.rputs "hello trusterd!"
+    s.rputs("retrun = [" + Libtrusterd::Cgi.cgi_proc("{uri:hoge,param:1}")+"]\n")
   }
 end
 if s.request.uri == "/exit"

--- a/examples/test.conf.rb
+++ b/examples/test.conf.rb
@@ -113,8 +113,8 @@ s = HTTP2::Server.new({
 #     s.enable_shared_mruby
 #   end
 if s.request.uri == "/cgi"
-  #pp s.request
-  #p "cgi"
+  p s.request
+  p "cgi"
 
   s.set_content_cb {
     s.rputs s.unparsed_uri+"\n"

--- a/examples/test.conf.rb
+++ b/examples/test.conf.rb
@@ -78,7 +78,7 @@ s = HTTP2::Server.new({
 #
 # when :callback option is true,
 #
- s.set_map_to_strage_cb {
+ s.set_map_to_storage_cb {
 #
 #   p "callback bloack at set_map_to_strage_cb"
 #   p s.request.uri
@@ -121,19 +121,27 @@ if s.request.uri == "/cgi"
     if s.body
       s.rputs s.body+"\n"
     end
-    s.rputs("retrun = [" + Libtrusterd::Cgi.cgi_proc("{uri:hoge,param:1}")+"]\n")
+    myres = Libtrusterd::Cgi.cgi_proc("{uri:hoge,param:1}")
+    s.rputs("retrun = ["+myres+"]\n")
+    myres = ""
   }
 end
 
 if s.request.uri == "/test"
-  p s.request
-  p "test"
-  MyCall.my_exec("this is trusterd!")
+  #p s.request
+  #p "test"
+  #MyCall.my_exec("this is trusterd!")
+
+  $counter = $counter + 1
+  if ($counter%100000==0)
+    #GC.start
+  end
+
   s.set_content_cb {
-    s.rputs s.unparsed_uri+"\n"
-    if s.body
-      s.rputs s.body+"\n"
-    end
+    #s.rputs s.unparsed_uri+"\n"
+    #if s.body
+    #  s.rputs s.body+"\n"
+    #end
     s.rputs "hello trusterd!"
   }
 end
@@ -181,5 +189,6 @@ end
 #   f.write "#{s.conn.client_ip} #{Time.now} - #{s.r.uri} - #{s.r.filename}\n"
 #
 # }
+$counter=1
 s.run
 p 123

--- a/examples/test.conf.rb
+++ b/examples/test.conf.rb
@@ -121,19 +121,27 @@ if s.request.uri == "/cgi"
     if s.body
       s.rputs s.body+"\n"
     end
-    s.rputs("retrun = [" + Libtrusterd::Cgi.cgi_proc("{uri:hoge,param:1}")+"]\n")
+    myres = Libtrusterd::Cgi.cgi_proc("{uri:hoge,param:1}")
+    s.rputs("retrun = ["+myres+"]\n")
+    myres = ""
   }
 end
 
 if s.request.uri == "/test"
-  p s.request
-  p "test"
-  MyCall.my_exec("this is trusterd!")
+  #p s.request
+  #p "test"
+  #MyCall.my_exec("this is trusterd!")
+
+  $counter = $counter + 1
+  if ($counter%100000==0)
+    #GC.start
+  end
+
   s.set_content_cb {
-    s.rputs s.unparsed_uri+"\n"
-    if s.body
-      s.rputs s.body+"\n"
-    end
+    #s.rputs s.unparsed_uri+"\n"
+    #if s.body
+    #  s.rputs s.body+"\n"
+    #end
     s.rputs "hello trusterd!"
   }
 end
@@ -181,5 +189,6 @@ end
 #   f.write "#{s.conn.client_ip} #{Time.now} - #{s.r.uri} - #{s.r.filename}\n"
 #
 # }
+$counter=1
 s.run
 p 123

--- a/examples/test.conf.rb
+++ b/examples/test.conf.rb
@@ -112,9 +112,9 @@ s = HTTP2::Server.new({
 #   if s.request.filename =~ /^.*\_shared.rb$/
 #     s.enable_shared_mruby
 #   end
-if s.request.uri == "/test"
+if s.request.uri == "/cgi"
   p s.request
-  p "test"
+  p "cgi"
 
   s.set_content_cb {
     s.rputs s.unparsed_uri+"\n"
@@ -124,6 +124,20 @@ if s.request.uri == "/test"
     s.rputs("retrun = [" + Libtrusterd::Cgi.cgi_proc("{uri:hoge,param:1}")+"]\n")
   }
 end
+
+if s.request.uri == "/test"
+  p s.request
+  p "test"
+  MyCall.my_exec("this is trusterd!")
+  s.set_content_cb {
+    s.rputs s.unparsed_uri+"\n"
+    if s.body
+      s.rputs s.body+"\n"
+    end
+    s.rputs "hello trusterd!"
+  }
+end
+
 if s.request.uri == "/exit"
   p "exit"
   s.set_content_cb {

--- a/examples/test.conf.rb
+++ b/examples/test.conf.rb
@@ -113,8 +113,8 @@ s = HTTP2::Server.new({
 #     s.enable_shared_mruby
 #   end
 if s.request.uri == "/cgi"
-  p s.request
-  p "cgi"
+  #pp s.request
+  #p "cgi"
 
   s.set_content_cb {
     s.rputs s.unparsed_uri+"\n"

--- a/examples/test.conf.rb
+++ b/examples/test.conf.rb
@@ -138,7 +138,7 @@ if s.request.uri == "/test"
   end
 
   s.set_content_cb {
-    #s.rputs s.unparsed_uri+"\n"
+    s.rputs s.unparsed_uri+"\n"
     #if s.body
     #  s.rputs s.body+"\n"
     #end

--- a/examples/testCgi.js
+++ b/examples/testCgi.js
@@ -9,6 +9,8 @@ var mylib = ffi.Library('./libtrusterd', {
   'boot_from_file_path_cgi': ['int', ['string', funcCgiPtr]]
 });
 
+var counter=0;
+
 // onReult will call by trusterd.
 var onResult = function(resultVal) {
   console.log('Result is', resultVal);
@@ -17,6 +19,11 @@ var onResult = function(resultVal) {
 
 var onRequest = function(resultVal) {
   //console.log('Result is', resultVal);
+  if(counter>501000) {
+
+    console.log(process.memoryUsage());
+  }
+  counter++;
   return "<html>Hello, trusted,this is node.js.["+resultVal+"]</html>";
 }
 // start http2 trusterd.

--- a/examples/testCgi.js
+++ b/examples/testCgi.js
@@ -1,0 +1,24 @@
+var fs = require('fs');
+var ref = require('ref');
+var ffi = require('ffi');
+
+var funcPtr = ffi.Function('int', ['string']);
+var funcCgiPtr = ffi.Function('string', ['string']);
+var mylib = ffi.Library('./libtrusterd', {
+  'boot_from_file_path': ['int', ['string', funcPtr]],
+  'boot_from_file_path_cgi': ['int', ['string', funcCgiPtr]]
+});
+
+// onReult will call by trusterd.
+var onResult = function(resultVal) {
+  console.log('Result is', resultVal);
+  return 0;
+}
+
+var onRequest = function(resultVal) {
+  console.log('Result is', resultVal);
+  return "<html>Hello, trusted,this is node.js.</html>";
+}
+// start http2 trusterd.
+mylib.boot_from_file_path_cgi("examples/test.conf.rb",onRequest);
+//

--- a/examples/testCgi.js
+++ b/examples/testCgi.js
@@ -16,8 +16,8 @@ var onResult = function(resultVal) {
 }
 
 var onRequest = function(resultVal) {
-  console.log('Result is', resultVal);
-  return "<html>Hello, trusted,this is node.js.</html>";
+  //console.log('Result is', resultVal);
+  return "<html>Hello, trusted,this is node.js.["+resultVal+"]</html>";
 }
 // start http2 trusterd.
 mylib.boot_from_file_path_cgi("examples/test.conf.rb",onRequest);

--- a/examples/testOnly.js
+++ b/examples/testOnly.js
@@ -3,8 +3,10 @@ var ref = require('ref');
 var ffi = require('ffi');
 
 var funcPtr = ffi.Function('int', ['string']);
+var funcCgiPtr = ffi.Function('string', ['string']);
 var mylib = ffi.Library('./libtrusterd', {
-  'boot_from_file_path': ['int', ['string', funcPtr]]
+  'boot_from_file_path': ['int', ['string', funcPtr]],
+  'boot_from_file_path_cgi': ['int', ['string', funcCgiPtr]]
 });
 
 // onReult will call by trusterd.
@@ -13,6 +15,10 @@ var onResult = function(resultVal) {
   return 0;
 }
 
+var onRequest = function(resultVal) {
+  console.log('Result is', resultVal);
+  return "<html>Hello, trusted,this is node.js.</html>";
+}
 // start http2 trusterd.
-mylib.boot_from_file_path("examples/test.conf.rb",onResult);
+mylib.boot_from_file_path_cgi("examples/test.conf.rb",onRequest);
 //

--- a/examples/testOnly.js
+++ b/examples/testOnly.js
@@ -20,5 +20,5 @@ var onRequest = function(resultVal) {
   return "<html>Hello, trusted,this is node.js.</html>";
 }
 // start http2 trusterd.
-mylib.boot_from_file_path("examples/test.conf.rb",onResult);
+mylib.boot_from_file_path_cgi("examples/test.conf.rb",onRequest);
 //

--- a/examples/testOnly.js
+++ b/examples/testOnly.js
@@ -20,5 +20,5 @@ var onRequest = function(resultVal) {
   return "<html>Hello, trusted,this is node.js.</html>";
 }
 // start http2 trusterd.
-mylib.boot_from_file_path_cgi("examples/test.conf.rb",onRequest);
+mylib.boot_from_file_path("examples/test.conf.rb",onResult);
 //

--- a/examples/trusterd.py
+++ b/examples/trusterd.py
@@ -11,13 +11,27 @@ else:
 trusterd_module = CDLL('../libtrusterd'+libext)
 trusterd_boot_func = trusterd_module.boot_from_file_path
 trusterd_boot_func.restype = c_int
+trusterd_boot_cgi_func = trusterd_module.boot_from_file_path_cgi
+trusterd_boot_cgi_func.restype = c_int
 
 def py_cb_func(script):
   print("py_cb_func",script)
   return 0
 
+def py_cb_cgi_func(script):
+  print("py_cb_cgi_func",script)
+  msg = "Hello, Trusterd.this is Python."
+  buf = create_string_buffer(msg.encode('UTF-8'))
+  c = ctypes.cast(buf, ctypes.POINTER(ctypes.c_char))
+  #return POINTER(b"Hello, Trusterd.this is Python.")
+  return ctypes.addressof(c.contents)
+
 CBFUNC=CFUNCTYPE(c_int,c_char_p)
 cbfunc=CBFUNC(py_cb_func)
+CBCGIFUNC=CFUNCTYPE(c_char_p,c_char_p)
+cbcgifunc=CBCGIFUNC(py_cb_cgi_func)
+
 path = "./test.conf.rb"
-ret = trusterd_boot_func(create_string_buffer(path.encode('UTF-8')),cbfunc)
+#ret = trusterd_boot_func(create_string_buffer(path.encode('UTF-8')),cbfunc)
+ret = trusterd_boot_cgi_func(create_string_buffer(path.encode('UTF-8')),cbcgifunc)
 print ('trusterd_boot_func returned:', ret)

--- a/examples/trusterd.py
+++ b/examples/trusterd.py
@@ -19,15 +19,16 @@ def py_cb_func(script):
   return 0
 
 def py_cb_cgi_func(script):
-  print("py_cb_cgi_func",script)
+  #print("py_cb_cgi_func",script)
   msg = "Hello, Trusterd.this is Python."
   buf = create_string_buffer(msg.encode('UTF-8'))
-  c = ctypes.cast(buf, ctypes.POINTER(ctypes.c_char))
-  #return POINTER(b"Hello, Trusterd.this is Python.")
-  return ctypes.addressof(c.contents)
+  c = cast(buf, POINTER(c_char))
+  return addressof(c.contents)
+  #return buf
 
 CBFUNC=CFUNCTYPE(c_int,c_char_p)
 cbfunc=CBFUNC(py_cb_func)
+#CBCGIFUNC=CFUNCTYPE(c_int,c_char_p)
 CBCGIFUNC=CFUNCTYPE(c_char_p,c_char_p)
 cbcgifunc=CBCGIFUNC(py_cb_cgi_func)
 

--- a/examples/trusterd.py
+++ b/examples/trusterd.py
@@ -19,16 +19,15 @@ def py_cb_func(script):
   return 0
 
 def py_cb_cgi_func(script):
-  #print("py_cb_cgi_func",script)
+  print("py_cb_cgi_func",script)
   msg = "Hello, Trusterd.this is Python."
   buf = create_string_buffer(msg.encode('UTF-8'))
-  c = cast(buf, POINTER(c_char))
-  return addressof(c.contents)
-  #return buf
+  c = ctypes.cast(buf, ctypes.POINTER(ctypes.c_char))
+  #return POINTER(b"Hello, Trusterd.this is Python.")
+  return ctypes.addressof(c.contents)
 
 CBFUNC=CFUNCTYPE(c_int,c_char_p)
 cbfunc=CBFUNC(py_cb_func)
-#CBCGIFUNC=CFUNCTYPE(c_int,c_char_p)
 CBCGIFUNC=CFUNCTYPE(c_char_p,c_char_p)
 cbcgifunc=CBCGIFUNC(py_cb_cgi_func)
 

--- a/examples/trusterdML.ml
+++ b/examples/trusterdML.ml
@@ -19,17 +19,20 @@ begin
  -1;
 end
 
+let response_str = "This is Ocaml.";;
+
 let g x =
 begin
  (*print_string x;*)
- "This is OCaml.";
+ x.[1] <- 'z';
+ response_str;
 end
 
 let read_file filename =
  let chan = open_in filename in
   Std.input_all chan
 
-let rbscript = read_file "../trusterd.conf.rb";;
+let rbscript = read_file "test.conf.rb";;
 
-(*boot rbscript f *)
-boot_cgi "./test.conf.rb" g
+boot rbscript f
+(*boot_cgi "./test.conf.rb" g*)

--- a/examples/trusterdML.ml
+++ b/examples/trusterdML.ml
@@ -5,9 +5,13 @@ open Std
 
 let cb_t = string @-> returning int;;
 
+let cgi_cb_t = string @-> returning string;;
+
 Dl.dlopen ~filename:"../libtrusterd.dylib" ~flags:[Dl.RTLD_NOW]
 
 let boot = foreign "boot" (string @-> funptr cb_t @-> returning int)
+
+let boot_cgi = foreign "boot_from_file_path_cgi" (string @-> funptr cgi_cb_t @-> returning int)
 
 let f x =
 begin
@@ -15,6 +19,11 @@ begin
  -1;
 end
 
+let g x =
+begin
+ (*print_string x;*)
+ "This is OCaml.";
+end
 
 let read_file filename =
  let chan = open_in filename in
@@ -22,4 +31,5 @@ let read_file filename =
 
 let rbscript = read_file "../trusterd.conf.rb";;
 
-boot rbscript f
+(*boot rbscript f *)
+boot_cgi "./test.conf.rb" g

--- a/trusterdBoot.c
+++ b/trusterdBoot.c
@@ -344,7 +344,7 @@ mrb_value exec(mrb_state* mrb, mrb_value self)
 
 mrb_value cgi_proc(mrb_state* mrb, mrb_value self)
 {
-<<<<<<< HEAD
+  char *script;
   mrb_value val;
   char *str;
 
@@ -352,8 +352,6 @@ mrb_value cgi_proc(mrb_state* mrb, mrb_value self)
   // 第一引数を引数にコールバック関数を実行する。
   mrb_get_args(mrb, "z", &script);
   str = (*getCgiCallback())(script);
-  //printf("%s\n",script);
-  val = mrb_str_new_cstr(mrb, str);
   /*free(str);*/
   return  val;
 }

--- a/trusterdBoot.c
+++ b/trusterdBoot.c
@@ -346,7 +346,7 @@ mrb_value cgi_proc(mrb_state* mrb, mrb_value self)
 {
   char *script;
 
-  printf("cgi call: start\n");
+  //printf("cgi call: start\n");
   // 第一引数を引数にコールバック関数を実行する。
   mrb_get_args(mrb, "z", &script);
 

--- a/trusterdBoot.c
+++ b/trusterdBoot.c
@@ -352,6 +352,7 @@ mrb_value cgi_proc(mrb_state* mrb, mrb_value self)
   // 第一引数を引数にコールバック関数を実行する。
   mrb_get_args(mrb, "z", &script);
   str = (*getCgiCallback())(script);
+  //printf("%s\n",script);
   val = mrb_str_new_cstr(mrb, str);
   /*free(str);*/
   return  val;
@@ -437,6 +438,10 @@ int boot_from_file_path(char *filepath, FUNCPTR cb)
 
 int boot(char *name, FUNCPTR cb)
 {
+  mrb_value val;
+  struct RString *str;
+  char *err_out;
+
   assert(name != NULL);
   mrb_state* mrb = mrb_open();
 
@@ -445,6 +450,14 @@ int boot(char *name, FUNCPTR cb)
   mrbAddMyCallBack(mrb, cb);
 
   mrb_load_string(mrb, name);
+  if(mrb->exc) {
+      val = mrb_obj_value(mrb->exc);
+      if (mrb_type(val) == MRB_TT_STRING) {
+        str = mrb_str_ptr(val);
+        err_out = str->as.heap.ptr;
+        printf("%s\n",err_out);
+      }
+  }
   mrb_close(mrb);
   return printf("%s", name);
 }

--- a/trusterdBoot.c
+++ b/trusterdBoot.c
@@ -352,7 +352,10 @@ mrb_value cgi_proc(mrb_state* mrb, mrb_value self)
   // 第一引数を引数にコールバック関数を実行する。
   mrb_get_args(mrb, "z", &script);
   str = (*getCgiCallback())(script);
+<<<<<<< HEAD
   //printf("%s\n",script);
+=======
+>>>>>>> update examples
   val = mrb_str_new_cstr(mrb, str);
   /*free(str);*/
   return  val;

--- a/trusterdBoot.c
+++ b/trusterdBoot.c
@@ -344,7 +344,7 @@ mrb_value exec(mrb_state* mrb, mrb_value self)
 
 mrb_value cgi_proc(mrb_state* mrb, mrb_value self)
 {
-  char *script;
+<<<<<<< HEAD
   mrb_value val;
   char *str;
 

--- a/trusterdBoot.c
+++ b/trusterdBoot.c
@@ -384,7 +384,7 @@ void mrbAddCgiCallBack(mrb_state* mrb, FUNCCGIPTR cb)
   // クラスを定義する
   cls = mrb_define_class_under(mrb, module, "Cgi", mrb->object_class);
   // クラスメソッドを定義する
-  mrb_define_class_method(mrb, cls, "cgi_proc", cgi_proc, ARGS_REQ(1));
+  mrb_define_class_method(mrb, cls, "cgi_proc", cgi_proc, MRB_ARGS_REQ(1));
 }
 int watchTrusterdConfFile(mrb_state *mrb, char *filepath)
 {

--- a/trusterdBoot.c
+++ b/trusterdBoot.c
@@ -353,9 +353,13 @@ mrb_value cgi_proc(mrb_state* mrb, mrb_value self)
   mrb_get_args(mrb, "z", &script);
   str = (*getCgiCallback())(script);
 <<<<<<< HEAD
+<<<<<<< HEAD
   //printf("%s\n",script);
 =======
 >>>>>>> update examples
+=======
+  //printf("%s\n",script);
+>>>>>>> update some files
   val = mrb_str_new_cstr(mrb, str);
   /*free(str);*/
   return  val;

--- a/trusterdBoot.c
+++ b/trusterdBoot.c
@@ -26,6 +26,10 @@
 
 typedef int (*FUNCPTR)(char *script);
 FUNCPTR gcb;
+
+typedef char *(*FUNCCGIPTR)(char *request_json);
+FUNCCGIPTR gcgicb;
+
 char trusterd_conf_path[1024];
 FILE *confFile = NULL;
 
@@ -60,6 +64,17 @@ FUNCPTR getCallback()
 {
   return gcb;
 }
+
+void setCgiCallback(FUNCCGIPTR cb)
+{
+  gcgicb = cb;
+}
+
+FUNCCGIPTR getCgiCallback()
+{
+  return gcgicb;
+}
+
 /*
    static mrb_value runTrusterd(mrb_state *mrb, mrb_value obj)
    {
@@ -320,12 +335,22 @@ mrb_value exec(mrb_state* mrb, mrb_value self)
 {
   char *script;
 
-  printf("class:Call, method:py_exec\n");
+  printf("class:Call, method:exec\n");
   // 第一引数を引数にコールバック関数を実行する。
   mrb_get_args(mrb, "z", &script);
 
-  (*getCallback())(script);
-  return self;
+  return  mrb_fixnum_value((*getCallback())(script));
+}
+
+mrb_value cgi_proc(mrb_state* mrb, mrb_value self)
+{
+  char *script;
+
+  printf("cgi call: start\n");
+  // 第一引数を引数にコールバック関数を実行する。
+  mrb_get_args(mrb, "z", &script);
+
+  return  mrb_str_new_cstr(mrb,(*getCgiCallback())(script));
 }
 
 void mrbAddMyCallBack(mrb_state* mrb, FUNCPTR cb)
@@ -343,6 +368,19 @@ void mrbAddMyCallBack(mrb_state* mrb, FUNCPTR cb)
         #endif
 }
 
+void mrbAddCgiCallBack(mrb_state* mrb, FUNCCGIPTR cb)
+{
+  setCgiCallback(cb);
+
+  struct RClass *module, *cls;
+
+  module = mrb_module_get(mrb, "Libtrusterd");
+
+  // クラスを定義する
+  cls = mrb_define_class_under(mrb, module, "Cgi", mrb->object_class);
+  // クラスメソッドを定義する
+  mrb_define_class_method(mrb, cls, "cgi_proc", cgi_proc, ARGS_REQ(1));
+}
 int watchTrusterdConfFile(mrb_state *mrb, char *filepath)
 {
         #ifdef __APPLE__
@@ -353,6 +391,25 @@ int watchTrusterdConfFile(mrb_state *mrb, char *filepath)
 
 #endif
   return -1;
+}
+
+int boot_from_file_path_cgi(char *filepath, FUNCCGIPTR cb)
+{
+  int rtn;
+
+  assert(filepath != NULL);
+
+  mrb_state* mrb = mrb_open();
+  mrb_load_irep(mrb, commonUtil);
+
+  mrbAddCgiCallBack(mrb, cb);
+
+  rtn = watchTrusterdConfFile(mrb, filepath);
+  //mrb_load_string(mrb, name);
+
+  mrb_close(mrb);
+  //printf("we now return[%d]\n",rtn);
+  return rtn;
 }
 
 int boot_from_file_path(char *filepath, FUNCPTR cb)

--- a/trusterdBoot.c
+++ b/trusterdBoot.c
@@ -345,12 +345,16 @@ mrb_value exec(mrb_state* mrb, mrb_value self)
 mrb_value cgi_proc(mrb_state* mrb, mrb_value self)
 {
   char *script;
+  mrb_value val;
+  char *str;
 
   //printf("cgi call: start\n");
   // 第一引数を引数にコールバック関数を実行する。
   mrb_get_args(mrb, "z", &script);
-
-  return  mrb_str_new_cstr(mrb,(*getCgiCallback())(script));
+  str = (*getCgiCallback())(script);
+  val = mrb_str_new_cstr(mrb, str);
+  /*free(str);*/
+  return  val;
 }
 
 void mrbAddMyCallBack(mrb_state* mrb, FUNCPTR cb)

--- a/trusterdBoot.c
+++ b/trusterdBoot.c
@@ -352,6 +352,9 @@ mrb_value cgi_proc(mrb_state* mrb, mrb_value self)
   // 第一引数を引数にコールバック関数を実行する。
   mrb_get_args(mrb, "z", &script);
   str = (*getCgiCallback())(script);
+  val = mrb_str_new_cstr(mrb, str);
+  /*free(str);*/
+  return  val;
 }
 
 void mrbAddMyCallBack(mrb_state* mrb, FUNCPTR cb)

--- a/trusterdBoot.c
+++ b/trusterdBoot.c
@@ -352,8 +352,6 @@ mrb_value cgi_proc(mrb_state* mrb, mrb_value self)
   // 第一引数を引数にコールバック関数を実行する。
   mrb_get_args(mrb, "z", &script);
   str = (*getCgiCallback())(script);
-  /*free(str);*/
-  return  val;
 }
 
 void mrbAddMyCallBack(mrb_state* mrb, FUNCPTR cb)
@@ -382,7 +380,7 @@ void mrbAddCgiCallBack(mrb_state* mrb, FUNCCGIPTR cb)
   // クラスを定義する
   cls = mrb_define_class_under(mrb, module, "Cgi", mrb->object_class);
   // クラスメソッドを定義する
-  mrb_define_class_method(mrb, cls, "cgi_proc", cgi_proc, ARGS_REQ(1));
+  mrb_define_class_method(mrb, cls, "cgi_proc", cgi_proc, MRB_ARGS_REQ(1));
 }
 int watchTrusterdConfFile(mrb_state *mrb, char *filepath)
 {


### PR DESCRIPTION
- write response in your favorite language which support libffi

``` js
var onRequest = function(req) {
  console.log('Result is', resultVal);
  // Parse req and return result.
  return "<html>Hello, trusted,this is node.js.</html>";
}
// start http2 trusterd.
mylib.boot_from_file_path_cgi("examples/test.conf.rb",onRequest);
```

``` rb
s.set_map_to_storage_cb {
if s.request.uri == "/test"
  p s.request
  s.set_content_cb {
    s.rputs s.unparsed_uri+"\n"
    if s.body
      s.rputs s.body+"\n"
    end
    s.rputs Libtrusterd::Cgi.cgi_proc(SomethinReqObj)
  }
end
```
## TODO
- implement like request object
